### PR TITLE
Add mime type filter for CSV and JSON

### DIFF
--- a/biaquiz-core/biaquiz-core.php
+++ b/biaquiz-core/biaquiz-core.php
@@ -103,7 +103,8 @@ class BIAQuiz_Core {
             'includes/class-acf-integration.php',
             'includes/class-admin.php',
             'includes/class-import-export.php',
-            'includes/class-quiz-handler.php'
+            'includes/class-quiz-handler.php',
+            'includes/mime-types.php'
         );
         
         foreach ($files as $file) {

--- a/biaquiz-core/includes/mime-types.php
+++ b/biaquiz-core/includes/mime-types.php
@@ -1,0 +1,18 @@
+<?php
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Allow CSV and JSON uploads.
+ *
+ * @param array $mimes Existing allowed mime types.
+ * @return array Modified mime types.
+ */
+function biaquiz_core_allowed_mimes($mimes) {
+    $mimes['csv']  = 'text/csv';
+    $mimes['json'] = 'application/json';
+    return $mimes;
+}
+add_filter('upload_mimes', 'biaquiz_core_allowed_mimes');


### PR DESCRIPTION
## Summary
- create `mime-types.php` to allow CSV and JSON uploads
- include new file in plugin dependencies

## Testing
- `php -l biaquiz-core/includes/mime-types.php` *(fails: command not found)*
- `php -l biaquiz-core/biaquiz-core.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a83d0460832ba8629ec67eb05ae7