### PR TITLE
Fix duplicate admin menu in BIAQuiz

### DIFF
--- a/biaquiz-core/includes/class-post-types.php
+++ b/biaquiz-core/includes/class-post-types.php
@@ -72,7 +72,9 @@ class BIAQuiz_Post_Types {
             'hierarchical'          => false,
             'public'                => true,
             'show_ui'               => true,
-            'show_in_menu'          => true,
+            // Place the Quiz BIA menu under the main BIAQuiz dashboard to
+            // avoid displaying two separate admin links in the sidebar
+            'show_in_menu'          => 'biaquiz-dashboard',
             'menu_position'         => 25,
             'menu_icon'             => 'dashicons-clipboard',
             'show_in_admin_bar'     => true,


### PR DESCRIPTION
## Summary
- avoid duplicate admin menu entries for quiz CPT by showing the CPT under the main plugin dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863af7a73bc832b81c762acc1ec7a3d